### PR TITLE
Custom Player and Dino Level Changes (Ark v218)

### DIFF
--- a/ARK Server Manager/Lib/GameData.cs
+++ b/ARK Server Manager/Lib/GameData.cs
@@ -331,6 +331,12 @@ namespace ARK_Server_Manager.Lib
                 new Level {XPRequired=27105 , EngramPoints=0},
                 new Level {XPRequired=31505 , EngramPoints=0},
                 new Level {XPRequired=36005 , EngramPoints=0},
+                new Level {XPRequired=41000 , EngramPoints=0},
+                new Level {XPRequired=47000 , EngramPoints=0},
+                new Level {XPRequired=55000 , EngramPoints=0},
+                new Level {XPRequired=65000 , EngramPoints=0},
+                new Level {XPRequired=80000 , EngramPoints=0},
+                new Level {XPRequired=98000 , EngramPoints=0},
             };
 
         private static readonly Level[] levelProgressionPlayerOfficial = new Level[]
@@ -420,6 +426,9 @@ namespace ARK_Server_Manager.Lib
                 new Level {XPRequired=289681, EngramPoints=50},
                 new Level {XPRequired=323189, EngramPoints=50},
                 new Level {XPRequired=360886, EngramPoints=50},
+                new Level {XPRequired=403318, EngramPoints=60},
+                new Level {XPRequired=451484, EngramPoints=60},
+                new Level {XPRequired=506186, EngramPoints=60},
             };
 
         public static IEnumerable<EngramEntry> GetStandardEngramOverrides() => engrams.Select(d => d.Duplicate<EngramEntry>());

--- a/ARK Server Manager/Lib/Model/ServerProfile.cs
+++ b/ARK Server Manager/Lib/Model/ServerProfile.cs
@@ -168,8 +168,8 @@ namespace ARK_Server_Manager.Lib
         public static readonly DependencyProperty IsDirtyProperty = DependencyProperty.Register(nameof(IsDirty), typeof(bool), typeof(ServerProfile), new PropertyMetadata(false));
         public static readonly DependencyProperty GlobalSpoilingTimeMultiplierProperty = DependencyProperty.Register(nameof(GlobalSpoilingTimeMultiplier), typeof(float), typeof(ServerProfile), new PropertyMetadata(1.0f));
         public static readonly DependencyProperty GlobalCorpseDecompositionTimeMultiplierProperty = DependencyProperty.Register(nameof(GlobalCorpseDecompositionTimeMultiplier), typeof(float), typeof(ServerProfile), new PropertyMetadata(1.0f));
-        public static readonly DependencyProperty OverrideMaxExperiencePointsDinoProperty = DependencyProperty.Register(nameof(OverrideMaxExperiencePointsDino), typeof(int), typeof(ServerProfile), new PropertyMetadata(100000));
-        public static readonly DependencyProperty OverrideMaxExperiencePointsPlayerProperty = DependencyProperty.Register(nameof(OverrideMaxExperiencePointsPlayer), typeof(int), typeof(ServerProfile), new PropertyMetadata(360887));
+        public static readonly DependencyProperty OverrideMaxExperiencePointsDinoProperty = DependencyProperty.Register(nameof(OverrideMaxExperiencePointsDino), typeof(int), typeof(ServerProfile), new PropertyMetadata(150000));
+        public static readonly DependencyProperty OverrideMaxExperiencePointsPlayerProperty = DependencyProperty.Register(nameof(OverrideMaxExperiencePointsPlayer), typeof(int), typeof(ServerProfile), new PropertyMetadata(506187));
         public static readonly DependencyProperty GlobalItemDecompositionTimeMultiplierProperty = DependencyProperty.Register(nameof(GlobalItemDecompositionTimeMultiplier), typeof(float), typeof(ServerProfile), new PropertyMetadata(1.0f));
 
         [IniFileEntry(IniFiles.GameUserSettings, IniFileSections.ServerSettings, "GlobalVoiceChat")]


### PR DESCRIPTION
1.Updated the maximum XP cap for the player to the ARK official default.
2.Updated the maximum XP cap for the dino to the ARK official default.
3.Added the extra official dino levels.
4.Added the extra official player levels.
