### PR TITLE
Ark 218.7 Additions

### DIFF
--- a/ARK Server Manager/Lib/Model/ServerProfile.cs
+++ b/ARK Server Manager/Lib/Model/ServerProfile.cs
@@ -1081,6 +1081,14 @@ namespace ARK_Server_Manager.Lib
 
         public static readonly DependencyProperty SOTF_OnlyAdminRejoinAsSpectatorProperty = DependencyProperty.Register(nameof(SOTF_OnlyAdminRejoinAsSpectator), typeof(bool), typeof(ServerProfile), new PropertyMetadata(false));
 
+        public bool SOTF_GamePlayLogging
+        {
+            get { return (bool)GetValue(SOTF_GamePlayLoggingProperty); }
+            set { SetValue(SOTF_GamePlayLoggingProperty, value); }
+        }
+
+        public static readonly DependencyProperty SOTF_GamePlayLoggingProperty = DependencyProperty.Register(nameof(SOTF_GamePlayLogging), typeof(bool), typeof(ServerProfile), new PropertyMetadata(false));
+
 
         [IniFileEntry(IniFiles.GameUserSettings, IniFileSections.ServerSettings, Key = "MaxNumberOfPlayersInTribe", ConditionedOn = nameof(SOTF_Enabled))]
         public int SOTF_MaxNumberOfPlayersInTribe
@@ -1585,6 +1593,11 @@ namespace ARK_Server_Manager.Lib
                 if(this.SOTF_OnlyAdminRejoinAsSpectator)
                 {
                     serverArgs.Append(" -OnlyAdminRejoinAsSpectator");
+                }
+
+                if(this.SOTF_GamePlayLogging)
+                {
+                    serverArgs.Append(" -gameplaylogging");
                 }
             }
 

--- a/ARK Server Manager/Lib/Model/ServerProfile.cs
+++ b/ARK Server Manager/Lib/Model/ServerProfile.cs
@@ -1219,6 +1219,22 @@ namespace ARK_Server_Manager.Lib
 
         public static readonly DependencyProperty PerLevelStatsMultiplier_DinoWildProperty = DependencyProperty.Register(nameof(PerLevelStatsMultiplier_DinoWild), typeof(FloatIniValueArray), typeof(ServerProfile), new PropertyMetadata(null));
 
+        public static readonly DependencyProperty DisableAntiSpeedHackDetectionProperty = DependencyProperty.Register(nameof(DisableAntiSpeedHackDetection), typeof(bool), typeof(ServerProfile), new PropertyMetadata(false));
+
+        public bool DisableAntiSpeedHackDetection
+        {
+            get { return (bool)GetValue(DisableAntiSpeedHackDetectionProperty); }
+            set { SetValue(DisableAntiSpeedHackDetectionProperty, value); }
+        }
+
+        public static readonly DependencyProperty DisablePlayerMovePhysicsOptimizationProperty = DependencyProperty.Register(nameof(DisablePlayerMovePhysicsOptimization), typeof(bool), typeof(ServerProfile), new PropertyMetadata(false));
+
+        public bool DisablePlayerMovePhysicsOptimization
+        {
+            get { return (bool)GetValue(DisablePlayerMovePhysicsOptimizationProperty); }
+            set { SetValue(DisablePlayerMovePhysicsOptimizationProperty, value); }
+        }
+
         #endregion
 
         #region RCON Settings
@@ -1570,6 +1586,16 @@ namespace ARK_Server_Manager.Lib
                 {
                     serverArgs.Append(" -OnlyAdminRejoinAsSpectator");
                 }
+            }
+
+            if (this.DisableAntiSpeedHackDetection)
+            {
+                serverArgs.Append(" -noantispeedhack");
+            }
+
+            if (this.DisablePlayerMovePhysicsOptimization)
+            {
+                serverArgs.Append(" -nocombineclientmoves");
             }
 
             serverArgs.Append(' ');

--- a/ARK Server Manager/ServerSettingsControl.xaml
+++ b/ARK Server Manager/ServerSettingsControl.xaml
@@ -1734,6 +1734,7 @@
                                     <local:AnnotatedSlider Label="Auto-start Delay Time:" Value="{Binding SOTF_BattleAutoStartGameInterval}" Suffix="seconds" Minimum="5" Maximum="120" SmallChange="5" LargeChange="20" TickFrequency="10" ToolTip="The time after the minimum number of tribes has been achieved before the game starts."/>
                                     <local:AnnotatedSlider Label="Auto-restart Delay Time:" Value="{Binding SOTF_BattleAutoRestartGameInterval}" Suffix="seconds"  Minimum="5" Maximum="120" SmallChange="5" LargeChange="20" TickFrequency="10" ToolTip="The time after the last game has ended before the new game will start."/>
                                     <local:AnnotatedSlider Label="Sudden Death Time:" Value="{Binding SOTF_BattleSuddenDeathInterval}" Suffix="seconds" Minimum="60" Maximum="3600" SmallChange="60" LargeChange="600" TickFrequency="300" ToolTip="The amount of time Sudden Death will be in effect until the game is declared a draw."/>
+                                    <CheckBox IsChecked="{Binding SOTF_GamePlayLogging}" ToolTip="If checked, outputs a dated log file to \Saved folder, which will contain a timestamped kill and winners log listing steam id, steam name, character name, etc. Handy for automatic Tournament records.">Enable Game Play Logging</CheckBox>
                                 </StackPanel>
                             </GroupBox>
                         </Grid>

--- a/ARK Server Manager/ServerSettingsControl.xaml
+++ b/ARK Server Manager/ServerSettingsControl.xaml
@@ -710,6 +710,7 @@
                                 <RowDefinition/>
                                 <RowDefinition/>
                                 <RowDefinition/>
+                                <RowDefinition/>
                             </Grid.RowDefinitions>
                             <GroupBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="6" Header="Name and Passwords" >
                                 <Grid>
@@ -901,7 +902,22 @@
                                 </Grid>
                             </GroupBox>
 
-                            <GroupBox Grid.Row="10" Grid.ColumnSpan="6" Header="Command Line">
+                            <GroupBox Grid.Row="10" Grid.ColumnSpan="6" Header="Server Options">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition/>
+                                        <ColumnDefinition/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition/>
+                                        <RowDefinition/>
+                                    </Grid.RowDefinitions>
+                                    <CheckBox x:Name="DisableAntiSpeedHackDetection" Grid.Column="0" Grid.Row="0" IsChecked="{Binding DisableAntiSpeedHackDetection}" Content="Disable Anti Speedhack Detection" VerticalAlignment="Center" HorizontalAlignment="Left"  Margin="5" ToolTip="If checked, the anti speedhack detection will be disabled."/>
+                                    <CheckBox x:Name="DisablePlayerMovePhysicsOptimization" Grid.Column="0" Grid.Row="1" IsChecked="{Binding DisablePlayerMovePhysicsOptimization}" Content="Disable Player-Move-Physics Optimization" VerticalAlignment="Center" HorizontalAlignment="Left"  Margin="5" ToolTip="If checked, the player-move-physics will be displayed."/>
+                                </Grid>
+                            </GroupBox>
+
+                            <GroupBox Grid.Row="11" Grid.ColumnSpan="6" Header="Command Line">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
1. Added the 2 new server commandline options to the Administration
   section.
2. Anti speedhack detection is now enabled by default.
   To disable it, use the server commandline "-noantispeedhack"
3. Server player-move-physics optimization is now enabled by default
   (improves perf).
   To disable it, use the server commandline "-nocombineclientmoves"

Note: These options are command line only, they are not saved in the INI
file.
