### PR TITLE
Ark Server Version Alternate

### DIFF
--- a/ARK Server Manager/App.config
+++ b/ARK Server Manager/App.config
@@ -123,6 +123,9 @@
             <setting name="AvailableVersionUrl" serializeAs="String">
                 <value>http://api.ark.bar/version</value>
             </setting>
+            <setting name="AvailableVersionUrl2" serializeAs="String">
+                <value>http://arkdedicated.com/version</value>
+            </setting>
             <setting name="ServerStatusUrlFormat" serializeAs="String">
                 <value>http://api.ark.bar/server/{0}/{1}</value>
             </setting>

--- a/ARK Server Manager/Config.Designer.cs
+++ b/ARK Server Manager/Config.Designer.cs
@@ -325,6 +325,15 @@ namespace ARK_Server_Manager {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("http://arkdedicated.com/version")]
+        public string AvailableVersionUrl2 {
+            get {
+                return ((string)(this["AvailableVersionUrl2"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("http://api.ark.bar/server/{0}/{1}")]
         public string ServerStatusUrlFormat {
             get {

--- a/ARK Server Manager/Config.settings
+++ b/ARK Server Manager/Config.settings
@@ -95,6 +95,9 @@
     <Setting Name="AvailableVersionUrl" Type="System.String" Scope="Application">
       <Value Profile="(Default)">http://api.ark.bar/version</Value>
     </Setting>
+    <Setting Name="AvailableVersionUrl2" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">http://arkdedicated.com/version</Value>
+    </Setting>
     <Setting Name="ServerStatusUrlFormat" Type="System.String" Scope="Application">
       <Value Profile="(Default)">http://api.ark.bar/server/{0}/{1}</Value>
     </Setting>

--- a/ARK Server Manager/Lib/NetworkUtils.cs
+++ b/ARK Server Manager/Lib/NetworkUtils.cs
@@ -122,6 +122,14 @@ namespace ARK_Server_Manager.Lib
 
         public class AvailableVersion
         {
+            public AvailableVersion()
+            {
+                IsValid = false;
+                Current = new Version(0, 0);
+                Upcoming = new Version(0, 0);
+                UpcomingETA = "unknown";
+            }
+
             public bool IsValid
             {
                 get;
@@ -201,12 +209,40 @@ namespace ARK_Server_Manager.Lib
 
                 if (upcomingStatus != null)
                 {
-                    result.UpcomingETA = (string)upcomingStatus;
-                }                
+                    result.UpcomingETA = upcomingStatus.ToString();
+                }
+
+                // if successful then exist here and return the result
+                return result;
             }
             catch (Exception ex)
             {
-                logger.Debug(String.Format("Exception checking for version: {0}\r\n{1}", ex.Message, ex.StackTrace));                
+                logger.Debug(String.Format("Exception checking for version (method 1): {0}\r\n{1}", ex.Message, ex.StackTrace));                
+            }
+
+            try
+            {
+                string webString;
+                using (var client = new WebClient())
+                {
+                    webString = await client.DownloadStringTaskAsync(Config.Default.AvailableVersionUrl2);
+                }
+
+                if (!string.IsNullOrWhiteSpace(webString))
+                {
+                    Version ver;
+                    string versionString = webString.ToString();
+                    if (versionString.IndexOf('.') == -1)
+                    {
+                        versionString = versionString + ".0";
+                    }
+                    result.IsValid = Version.TryParse(versionString, out ver);
+                    result.Current = ver;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Debug(String.Format("Exception checking for version (method 2): {0}\r\n{1}", ex.Message, ex.StackTrace));
             }
 
             return result;
@@ -214,6 +250,15 @@ namespace ARK_Server_Manager.Lib
 
         public class ServerNetworkInfo
         {
+            public ServerNetworkInfo()
+            {
+                Name = "unknown";
+                Version = new Version(0, 0);
+                Map = "unknown";
+                Players = 0;
+                MaxPlayers = 0;
+            }
+
             public string Name
             {
                 get;

--- a/ARK Server Manager/ServerSettingsControl.xaml
+++ b/ARK Server Manager/ServerSettingsControl.xaml
@@ -484,7 +484,7 @@
                         <Border Grid.Column="1" Background="{DynamicResource BeigeLabel}" Margin="2" BorderBrush="{DynamicResource BeigeBorder}" Style="{DynamicResource BorderLabel}" ToolTip="{DynamicResource ServerSettings_AvailableVersionTooltip}">
                             <StackPanel Orientation="Horizontal">
                                 <Label FontSize="15" Content="{DynamicResource ServerSettings_AvailableVersionLabel}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                <Label FontSize="15" Content="{Binding ElementName=SettingsControl, Path=ServerManager.AvailableVersion}" HorizontalAlignment="Left"/>
+                                <Label FontSize="15" Content="{Binding ElementName=SettingsControl, Path=ServerManager.AvailableVersion}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
 
                                 <Button Margin="5,0,0,0" Click="CheckForUpdates_Click" Width="22" Height="22" VerticalAlignment="Center"
                                         ToolTip="{DynamicResource ServerSettings_AvailableVersionRefreshTooltip}">


### PR DESCRIPTION
1. Have implemented a second Available Version retrieval method using
   arkdedicated.com. This method will only be used if Ark.Bar is NOT
   available.
   Note:
2. Only the Current version will be set, Upcoming and UpcomingETA will be
   defaulted.
3. Have added defaults to the AvailableVersion and ServerNetworkInfo
   classes.
