### PR TITLE
Ark.bar alternates

### DIFF
--- a/ARK Server Manager/App.config
+++ b/ARK Server Manager/App.config
@@ -123,6 +123,9 @@
             <setting name="AvailableVersionUrl" serializeAs="String">
                 <value>http://api.ark.bar/version</value>
             </setting>
+            <setting name="AvailableVersionUrl2" serializeAs="String">
+                <value>http://arkdedicated.com/version</value>
+            </setting>
             <setting name="ServerStatusUrlFormat" serializeAs="String">
                 <value>http://api.ark.bar/server/{0}/{1}</value>
             </setting>

--- a/ARK Server Manager/Config.Designer.cs
+++ b/ARK Server Manager/Config.Designer.cs
@@ -325,6 +325,15 @@ namespace ARK_Server_Manager {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("http://arkdedicated.com/version")]
+        public string AvailableVersionUrl2 {
+            get {
+                return ((string)(this["AvailableVersionUrl2"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("http://api.ark.bar/server/{0}/{1}")]
         public string ServerStatusUrlFormat {
             get {

--- a/ARK Server Manager/Config.settings
+++ b/ARK Server Manager/Config.settings
@@ -95,6 +95,9 @@
     <Setting Name="AvailableVersionUrl" Type="System.String" Scope="Application">
       <Value Profile="(Default)">http://api.ark.bar/version</Value>
     </Setting>
+    <Setting Name="AvailableVersionUrl2" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">http://arkdedicated.com/version</Value>
+    </Setting>
     <Setting Name="ServerStatusUrlFormat" Type="System.String" Scope="Application">
       <Value Profile="(Default)">http://api.ark.bar/server/{0}/{1}</Value>
     </Setting>

--- a/ARK Server Manager/Lib/Model/ServerRuntime.cs
+++ b/ARK Server Manager/Lib/Model/ServerRuntime.cs
@@ -503,7 +503,8 @@ namespace ARK_Server_Manager.Lib
                         }
                     }
 
-                    this.Players = update.ServerInfo.Players;
+                    // set the player count using the players list, as this should only contain the current valid players.
+                    this.Players = update.Players.Count;
                     this.MaxPlayers = update.ServerInfo.MaxPlayers;
                 }
 

--- a/ARK Server Manager/Lib/NetworkUtils.cs
+++ b/ARK Server Manager/Lib/NetworkUtils.cs
@@ -122,6 +122,14 @@ namespace ARK_Server_Manager.Lib
 
         public class AvailableVersion
         {
+            public AvailableVersion()
+            {
+                IsValid = false;
+                Current = new Version(0, 0);
+                Upcoming = new Version(0, 0);
+                UpcomingETA = "unknown";
+            }
+
             public bool IsValid
             {
                 get;
@@ -201,12 +209,40 @@ namespace ARK_Server_Manager.Lib
 
                 if (upcomingStatus != null)
                 {
-                    result.UpcomingETA = (string)upcomingStatus;
-                }                
+                    result.UpcomingETA = upcomingStatus.ToString();
+                }
+
+                // if successful then exist here and return the result
+                return result;
             }
             catch (Exception ex)
             {
-                logger.Debug(String.Format("Exception checking for version: {0}\r\n{1}", ex.Message, ex.StackTrace));                
+                logger.Debug(String.Format("Exception checking for version (method 1): {0}\r\n{1}", ex.Message, ex.StackTrace));                
+            }
+
+            try
+            {
+                string webString;
+                using (var client = new WebClient())
+                {
+                    webString = await client.DownloadStringTaskAsync(Config.Default.AvailableVersionUrl2);
+                }
+
+                if (!string.IsNullOrWhiteSpace(webString))
+                {
+                    Version ver;
+                    string versionString = webString.ToString();
+                    if (versionString.IndexOf('.') == -1)
+                    {
+                        versionString = versionString + ".0";
+                    }
+                    result.IsValid = Version.TryParse(versionString, out ver);
+                    result.Current = ver;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Debug(String.Format("Exception checking for version (method 2): {0}\r\n{1}", ex.Message, ex.StackTrace));
             }
 
             return result;
@@ -214,6 +250,15 @@ namespace ARK_Server_Manager.Lib
 
         public class ServerNetworkInfo
         {
+            public ServerNetworkInfo()
+            {
+                Name = "unknown";
+                Version = new Version(0, 0);
+                Map = "unknown";
+                Players = 0;
+                MaxPlayers = 0;
+            }
+
             public string Name
             {
                 get;

--- a/ARK Server Manager/Lib/NetworkUtils.cs
+++ b/ARK Server Manager/Lib/NetworkUtils.cs
@@ -350,5 +350,24 @@ namespace ARK_Server_Manager.Lib
 
             return result;
         }
+
+        public static ServerNetworkInfo GetServerNetworkInfo2(IPEndPoint endpoint)
+        {
+            ServerNetworkInfo result = null;
+            try
+            {
+                QueryMaster.ServerInfo serverInfo = null;
+                using (var server = QueryMaster.ServerQuery.GetServerInstance(QueryMaster.Game.ARKSurvivalEvolved, endpoint))
+                {
+                    serverInfo = server.GetInfo();
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Debug(String.Format("Exception checking status for: {0}:{1} {2}\r\n{3}", endpoint.Address, endpoint.Port, ex.Message, ex.StackTrace));
+            }
+
+            return result;
+        }
     }
 }

--- a/ARK Server Manager/Lib/ServerStatusWatcher.cs
+++ b/ARK Server Manager/Lib/ServerStatusWatcher.cs
@@ -308,7 +308,8 @@ namespace ARK_Server_Manager.Lib
                 // Now that it's running, we can check the publication status.
                 //
                 logger.Debug("Checking server public status at {0}", registration.SteamEndpoint);
-                var serverInfo = await NetworkUtils.GetServerNetworkInfo(registration.SteamEndpoint);
+                //var serverInfo = await NetworkUtils.GetServerNetworkInfo(registration.SteamEndpoint);
+                var serverInfo = NetworkUtils.GetServerNetworkInfo2(registration.SteamEndpoint);
                 if (serverInfo != null)
                 {                    
                     currentStatus = ServerStatus.Published;

--- a/ARK Server Manager/Lib/ServerStatusWatcher.cs
+++ b/ARK Server Manager/Lib/ServerStatusWatcher.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Management;
 using System.Net;
 using System.Net.Sockets;
@@ -296,9 +297,8 @@ namespace ARK_Server_Manager.Lib
             //
             // If the process was running do we then perform network checks.
             //
-            ServerInfo localInfo;
             ReadOnlyCollection<Player> players;
-            localInfo = GetLocalNetworkStatus(registration.LocalEndpoint, out players);
+            ServerInfo localInfo = GetLocalNetworkStatus(registration.LocalEndpoint, out players);
 
             if(localInfo != null)
             {
@@ -308,8 +308,12 @@ namespace ARK_Server_Manager.Lib
                 // Now that it's running, we can check the publication status.
                 //
                 logger.Debug("Checking server public status at {0}", registration.SteamEndpoint);
-                //var serverInfo = await NetworkUtils.GetServerNetworkInfo(registration.SteamEndpoint);
-                var serverInfo = NetworkUtils.GetServerNetworkInfo2(registration.SteamEndpoint);
+                // get the server information direct from the server.
+                var serverInfo = NetworkUtils.GetServerNetworkInfoDirect(registration.SteamEndpoint);
+                // check fi the server returned the information.
+                if (serverInfo == null)
+                    // server did not return any information, try to get the server information using 3rd party source.
+                    serverInfo = await NetworkUtils.GetServerNetworkInfo(registration.SteamEndpoint);
                 if (serverInfo != null)
                 {                    
                     currentStatus = ServerStatus.Published;
@@ -333,29 +337,25 @@ namespace ARK_Server_Manager.Lib
 
         private static ServerInfo GetLocalNetworkStatus(IPEndPoint specificEndpoint, out ReadOnlyCollection<Player> players)
         {
-            var server = ServerQuery.GetServerInstance(EngineType.Source, specificEndpoint);
-            ServerInfo serverInfo = null;
             players = null;
+
+            ServerInfo serverInfo = null;
             try
             {
-                serverInfo = server.GetInfo();
+                using (var server = ServerQuery.GetServerInstance(EngineType.Source, specificEndpoint))
+                {
+                    serverInfo = server.GetInfo();
+                    players = server.GetPlayers();
+                }
+
+                // return the list of valid players only.
+                if (players != null)
+                    players = new ReadOnlyCollection<Player>(players.Where(record => !string.IsNullOrWhiteSpace(record.Name)).ToList());
             }
             catch (SocketException ex)
             {
                 logger.Debug("GetInfo failed: {0}: {1}", specificEndpoint, ex.Message);
                 // Common when the server is unreachable.  Ignore it.
-            }
-
-            if (serverInfo != null)
-            {
-                try
-                {
-                    players = server.GetPlayers();
-                }
-                catch (SocketException)
-                {
-                    // Common when the server is unreachable.  Ignore it.
-                }
             }
 
             return serverInfo;

--- a/ARK Server Manager/ServerSettingsControl.xaml
+++ b/ARK Server Manager/ServerSettingsControl.xaml
@@ -484,7 +484,7 @@
                         <Border Grid.Column="1" Background="{DynamicResource BeigeLabel}" Margin="2" BorderBrush="{DynamicResource BeigeBorder}" Style="{DynamicResource BorderLabel}" ToolTip="{DynamicResource ServerSettings_AvailableVersionTooltip}">
                             <StackPanel Orientation="Horizontal">
                                 <Label FontSize="15" Content="{DynamicResource ServerSettings_AvailableVersionLabel}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                <Label FontSize="15" Content="{Binding ElementName=SettingsControl, Path=ServerManager.AvailableVersion}" HorizontalAlignment="Left"/>
+                                <Label FontSize="15" Content="{Binding ElementName=SettingsControl, Path=ServerManager.AvailableVersion}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
 
                                 <Button Margin="5,0,0,0" Click="CheckForUpdates_Click" Width="22" Height="22" VerticalAlignment="Center"
                                         ToolTip="{DynamicResource ServerSettings_AvailableVersionRefreshTooltip}">

--- a/QueryMaster/Enums.cs
+++ b/QueryMaster/Enums.cs
@@ -208,7 +208,11 @@ namespace QueryMaster
         /// <summary>
         /// Smashball
         /// </summary>
-        Smashball = 17730
+        Smashball = 17730,
+        /// <summary>
+        /// ARK: Survival Evolved
+        /// </summary>
+        ARKSurvivalEvolved = 346110,
     }
 
     /// <summary>

--- a/QueryMaster/Enums.cs
+++ b/QueryMaster/Enums.cs
@@ -209,10 +209,6 @@ namespace QueryMaster
         /// Smashball
         /// </summary>
         Smashball = 17730,
-        /// <summary>
-        /// ARK: Survival Evolved
-        /// </summary>
-        ARKSurvivalEvolved = 346110,
     }
 
     /// <summary>


### PR DESCRIPTION
I have added additional functionality to lessen the dependence on Ark.Bar. Every time Ark.Bar is offline, the support forums are flooded with complaints that ASM is not working properly.
1. Added a call to ArkDedicated.com for the Available Version if Ark.Bar is offline.
2. Added a direct server query (using QueryMaster library) to retrieve the server information and if failed, reverts to Ark.Bar to return the information.

NOTE:
I have changed the assignment of the current player count to use a list of valid players that is returned from the server. The list has been filtered to exclude any invalid players. This new count seems to align with the player count returned in the RCON window.
