### PR TITLE
RCON Window Features

### DIFF
--- a/ARK Server Manager/ARK Server Manager.csproj
+++ b/ARK Server Manager/ARK Server Manager.csproj
@@ -227,6 +227,9 @@
     <Compile Include="OpenRCON.xaml.cs">
       <DependentUpon>OpenRCON.xaml</DependentUpon>
     </Compile>
+    <Compile Include="PlayerProfile.xaml.cs">
+      <DependentUpon>PlayerProfile.xaml</DependentUpon>
+    </Compile>
     <Compile Include="RCONWindow.xaml.cs">
       <DependentUpon>RCONWindow.xaml</DependentUpon>
     </Compile>
@@ -236,6 +239,9 @@
     <Compile Include="Lib\ServerStatusWatcher.cs" />
     <Compile Include="Testing\UITests.xaml.cs">
       <DependentUpon>UITests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="TribeProfile.xaml.cs">
+      <DependentUpon>TribeProfile.xaml</DependentUpon>
     </Compile>
     <Compile Include="WPFControls\AnnotatedGlowSlider.xaml.cs">
       <DependentUpon>AnnotatedGlowSlider.xaml</DependentUpon>
@@ -266,7 +272,15 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="PlayerProfile.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Testing\UITests.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="TribeProfile.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/ARK Server Manager/Globalization/en-US/en-US.xaml
+++ b/ARK Server Manager/Globalization/en-US/en-US.xaml
@@ -516,4 +516,31 @@
     <sys:String x:Key="ServerSettings_EnableGamePlayLoggingLabel">Enable Game Play Logging</sys:String>
     <sys:String x:Key="ServerSettings_EnableGamePlayLoggingTooltip">If enabled, outputs a dated log file to \Saved folder, which will contain a timestamped kill and winners log listing steam id, steam name, character name, etc. Handy for automatic Tournament records.</sys:String>
 
+    <!-- Player/Tribe Profile Window -->
+    <sys:String x:Key="Profile_SteamSectionLabel">Steam Details</sys:String>
+    <sys:String x:Key="Profile_PlayerSectionLabel">Player Details</sys:String>
+    <sys:String x:Key="Profile_TribeSectionLabel">Tribe Details</sys:String>
+    <sys:String x:Key="Profile_TribeMembersSectionLabel">Tribe Members</sys:String>
+
+    <sys:String x:Key="Profile_IdLabel">Id:</sys:String>
+    <sys:String x:Key="Profile_NameLabel">Name:</sys:String>
+    <sys:String x:Key="Profile_OnlineLabel">Online:</sys:String>
+    <sys:String x:Key="Profile_CreatedLabel">Created:</sys:String>
+    <sys:String x:Key="Profile_UpdatedLabel">Last Updated:</sys:String>
+    <sys:String x:Key="Profile_BannedCommunityLabel">Community Banned:</sys:String>
+    <sys:String x:Key="Profile_BannedVACLabel">VAC Banned:</sys:String>
+    <sys:String x:Key="Profile_BannedVACCountLabel">Number of VAC Bans:</sys:String>
+    <sys:String x:Key="Profile_BannedVACDaysLabel">Days Since Last Ban:</sys:String>
+    <sys:String x:Key="Profile_LevelLabel">Level:</sys:String>
+    <sys:String x:Key="Profile_WhitelistedLabel">Whitelisted:</sys:String>
+    <sys:String x:Key="Profile_BannedLabel">Banned:</sys:String>
+    <sys:String x:Key="Profile_BannedGameCountLabel">Number of Game Bans:</sys:String>
+    <sys:String x:Key="Profile_TribeOwnerLabel">Owner:</sys:String>
+    <sys:String x:Key="Profile_SteamNameColumnLabel">Steam Name</sys:String>
+    <sys:String x:Key="Profile_CharacterNameColumnLabel">Character Name</sys:String>
+    <sys:String x:Key="Profile_LevelColumnLabel">Level</sys:String>
+    <sys:String x:Key="Profile_OnlineColumnLabel">Online</sys:String>
+    <sys:String x:Key="Profile_CreatedColumnLabel">Created</sys:String>
+    <sys:String x:Key="Profile_UpdatedColumnLabel">Last Updated</sys:String>
+
 </Globalization:GlobalizationResourceDictionary>

--- a/ARK Server Manager/Globalization/en-US/en-US.xaml
+++ b/ARK Server Manager/Globalization/en-US/en-US.xaml
@@ -542,5 +542,7 @@
     <sys:String x:Key="Profile_OnlineColumnLabel">Online</sys:String>
     <sys:String x:Key="Profile_CreatedColumnLabel">Created</sys:String>
     <sys:String x:Key="Profile_UpdatedColumnLabel">Last Updated</sys:String>
+    <sys:String x:Key="Profile_NavigateSteamProfile">Click to open the steam profile in a browser</sys:String>
+    <sys:String x:Key="Profile_NavigateProfile">Click to view the profile file in explorer</sys:String>
 
 </Globalization:GlobalizationResourceDictionary>

--- a/ARK Server Manager/PlayerProfile.xaml
+++ b/ARK Server Manager/PlayerProfile.xaml
@@ -1,0 +1,207 @@
+﻿<Window x:Class="ARK_Server_Manager.PlayerProfile"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:ARK_Server_Manager.Lib.ViewModel"
+        Title="{Binding WindowTitle}"
+        Width="500" ResizeMode="NoResize" SizeToContent="Height" Icon="Art/favicon.ico" WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Globalization\en-US\en-US.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <LinearGradientBrush x:Key="BeigeGradient" EndPoint="0.5,1" StartPoint="0.5,0">
+                <GradientStop Color="#FFECE1D4" Offset="1"/>
+                <GradientStop Color="#FFEAE8E6"/>
+            </LinearGradientBrush>
+            <vm:NullValueConverter x:Key="NullValueConverter"/>
+            <BitmapImage x:Key="NoAvatar" UriSource="Art/NoAvatar.png" />
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Background="{StaticResource BeigeGradient}">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <StackPanel Margin="10,2,10,2" CanVerticallyScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Row="0" Content="{DynamicResource Profile_NameLabel}"/>
+                <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333">
+                    <Hyperlink NavigateUri="{Binding ProfileUrl}" RequestNavigate="SteamName_RequestNavigate">
+                       <Hyperlink.Inlines>
+                            <Run Text="{Binding Player.SteamName}"/>
+                       </Hyperlink.Inlines>
+                    </Hyperlink>
+                </TextBlock>
+                <Image Grid.Row="0" Grid.Column="2" Grid.RowSpan="4" VerticalAlignment="Top" HorizontalAlignment="Right" Source="{Binding Player.AvatarImage, Converter={StaticResource ResourceKey=NullValueConverter}, ConverterParameter={StaticResource ResourceKey=NoAvatar}}" Width="48" Height="48" Stretch="Uniform"/>
+                <Label Grid.Row="1" Content="{DynamicResource Profile_OnlineLabel}"/>
+                <Label Grid.Row="1" Grid.Column="1" Content="{Binding Player.IsOnline}">
+                    <Label.Style>
+                        <Style TargetType="{x:Type Label}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Player.IsOnline}" Value="True">
+                                    <Setter Property="Foreground" Value="Green"/>
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Player.IsOnline}" Value="False">
+                                    <Setter Property="Foreground" Value="Red"/>
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Label.Style>
+                </Label>
+                <Label Grid.Row="2" Content="{DynamicResource Profile_CreatedLabel}"/>
+                <Label Grid.Row="2" Grid.Column="1" Content="{Binding CreatedDate}"/>
+                <Label Grid.Row="3" Content="{DynamicResource Profile_UpdatedLabel}"/>
+                <Label Grid.Row="3" Grid.Column="1" Content="{Binding UpdatedDate}"/>
+            </Grid>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_SteamSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding Player.SteamId}"/>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_BannedCommunityLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataPlayer.CommunityBanned}">
+                        <Label.Style>
+                            <Style TargetType="{x:Type Label}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ArkDataPlayer.CommunityBanned}" Value="False">
+                                        <Setter Property="Foreground" Value="Black"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ArkDataPlayer.CommunityBanned}" Value="True">
+                                        <Setter Property="Foreground" Value="Red"/>
+                                        <Setter Property="FontWeight" Value="Bold"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                    <Label Grid.Row="2" Content="{DynamicResource Profile_BannedVACLabel}"/>
+                    <Label Grid.Row="2" Grid.Column="1" Content="{Binding ArkDataPlayer.VACBanned}">
+                        <Label.Style>
+                            <Style TargetType="{x:Type Label}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ArkDataPlayer.VACBanned}" Value="False">
+                                        <Setter Property="Foreground" Value="Black"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding ArkDataPlayer.VACBanned}" Value="True">
+                                        <Setter Property="Foreground" Value="Red"/>
+                                        <Setter Property="FontWeight" Value="Bold"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                    <Label Grid.Row="3" Content="{DynamicResource Profile_BannedVACCountLabel}"/>
+                    <Label Grid.Row="3" Grid.Column="1" Content="{Binding ArkDataPlayer.NumberOfVACBans}"/>
+                    <Label Grid.Row="4" Content="{DynamicResource Profile_BannedVACDaysLabel}"/>
+                    <Label Grid.Row="4" Grid.Column="1" Content="{Binding ArkDataPlayer.DaysSinceLastBan}"/>
+                </Grid>
+            </GroupBox>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_PlayerSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding ArkDataPlayer.Id}"/>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_NameLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataPlayer.CharacterName}"/>
+                    <Label Grid.Row="2" Content="{DynamicResource Profile_LevelLabel}"/>
+                    <Label Grid.Row="2" Grid.Column="1" Content="{Binding ArkDataPlayer.Level}"/>
+                    <Label Grid.Row="3" Content="{DynamicResource Profile_WhitelistedLabel}"/>
+                    <Label Grid.Row="3" Grid.Column="1" Content="{Binding Player.IsWhitelisted}">
+                        <Label.Style>
+                            <Style TargetType="{x:Type Label}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Player.IsWhitelisted}" Value="True">
+                                        <Setter Property="Foreground" Value="Blue"/>
+                                        <Setter Property="FontWeight" Value="Bold"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Player.IsWhitelisted}" Value="False">
+                                        <Setter Property="Foreground" Value="Black"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                    <Label Grid.Row="4" Content="{DynamicResource Profile_BannedLabel}"/>
+                    <Label Grid.Row="4" Grid.Column="1" Content="{Binding Player.IsBanned}">
+                        <Label.Style>
+                            <Style TargetType="{x:Type Label}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Player.IsBanned}" Value="False">
+                                        <Setter Property="Foreground" Value="Black"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Player.IsBanned}" Value="True">
+                                        <Setter Property="Foreground" Value="Red"/>
+                                        <Setter Property="FontWeight" Value="Bold"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                    <Label Grid.Row="5" Content="{DynamicResource Profile_BannedGameCountLabel}"/>
+                    <Label Grid.Row="5" Grid.Column="1" Content="{Binding ArkDataPlayer.NumberOfGameBans}"/>
+                </Grid>
+            </GroupBox>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding ArkDataTribe.Id}"/>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_NameLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataTribe.Name}"/>
+                    <Label Grid.Row="2" Content="{DynamicResource Profile_TribeOwnerLabel}"/>
+                    <Label Grid.Row="2" Grid.Column="1" Content="{Binding TribeOwner}"/>
+                </Grid>
+            </GroupBox>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ARK Server Manager/PlayerProfile.xaml
+++ b/ARK Server Manager/PlayerProfile.xaml
@@ -35,7 +35,7 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <Label Grid.Row="0" Content="{DynamicResource Profile_NameLabel}"/>
-                <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333">
+                <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333" ToolTip="{DynamicResource Profile_NavigateSteamProfile}">
                     <Hyperlink NavigateUri="{Binding ProfileUrl}" RequestNavigate="SteamName_RequestNavigate">
                        <Hyperlink.Inlines>
                             <Run Text="{Binding Player.SteamName}"/>
@@ -139,7 +139,13 @@
                         <ColumnDefinition Width="2*"/>
                     </Grid.ColumnDefinitions>
                     <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
-                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding ArkDataPlayer.Id}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{DynamicResource Profile_NavigateProfile}">
+                        <Hyperlink NavigateUri="{Binding PlayerLink}" RequestNavigate="PlayerId_RequestNavigate">
+                           <Hyperlink.Inlines>
+                                <Run Text="{Binding ArkDataPlayer.Id}"/>
+                           </Hyperlink.Inlines>
+                        </Hyperlink>
+                    </TextBlock>
                     <Label Grid.Row="1" Content="{DynamicResource Profile_NameLabel}"/>
                     <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataPlayer.CharacterName}"/>
                     <Label Grid.Row="2" Content="{DynamicResource Profile_LevelLabel}"/>
@@ -195,7 +201,13 @@
                         <ColumnDefinition Width="2*"/>
                     </Grid.ColumnDefinitions>
                     <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
-                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding ArkDataTribe.Id}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{DynamicResource Profile_NavigateProfile}">
+                        <Hyperlink NavigateUri="{Binding TribeLink}" RequestNavigate="TribeId_RequestNavigate">
+                           <Hyperlink.Inlines>
+                                <Run Text="{Binding ArkDataTribe.Id}"/>
+                           </Hyperlink.Inlines>
+                        </Hyperlink>
+                    </TextBlock>
                     <Label Grid.Row="1" Content="{DynamicResource Profile_NameLabel}"/>
                     <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataTribe.Name}"/>
                     <Label Grid.Row="2" Content="{DynamicResource Profile_TribeOwnerLabel}"/>

--- a/ARK Server Manager/PlayerProfile.xaml.cs
+++ b/ARK Server Manager/PlayerProfile.xaml.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Navigation;
+using ARK_Server_Manager.Lib.ViewModel.RCON;
+using ArkData;
+
+namespace ARK_Server_Manager
+{
+    /// <summary>
+    /// Interaction logic for PlayerProfile.xaml
+    /// </summary>
+    public partial class PlayerProfile : Window
+    {
+        public PlayerProfile(PlayerInfo player)
+        {
+            InitializeComponent();
+
+            this.Player = player;
+            this.DataContext = this;
+        }
+
+        public PlayerInfo Player
+        {
+            get;
+            private set;
+        }
+
+        public Player ArkDataPlayer
+        {
+            get
+            {
+                return Player?.ArkData;
+            }
+        }
+
+        public Tribe ArkDataTribe
+        {
+            get
+            {
+                return Player?.ArkData?.Tribe;
+            }
+        }
+
+        public String CreatedDate
+        {
+            get
+            {
+                return ArkDataPlayer?.FileCreated.ToString("G");
+            }
+        }
+
+        public Boolean IsTribeOwner
+        {
+            get
+            {
+                return ArkDataPlayer != null && ArkDataTribe != null && ArkDataTribe.OwnerId == ArkDataPlayer.Id;
+            }
+        }
+
+        public String ProfileUrl
+        {
+            get
+            {
+                return ArkDataPlayer?.ProfileUrl;
+            }
+        }
+
+        public String TribeOwner
+        {
+            get
+            {
+                return ArkDataTribe != null && ArkDataTribe.Owner != null ? string.Format("{0} ({1})", ArkDataTribe.Owner.SteamName, ArkDataTribe.Owner.CharacterName) : null;
+            }
+        }
+
+        public String UpdatedDate
+        {
+            get
+            {
+                return ArkDataPlayer?.FileUpdated.ToString("G");
+            }
+        }
+
+        public String WindowTitle
+        {
+            get
+            {
+                return String.Format("Player Profile - {0}", Player.SteamName);
+            }
+        }
+
+        private void SteamName_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (sender.GetType() != typeof(Hyperlink)) return;
+
+            string link = ((Hyperlink)sender).NavigateUri.ToString();
+            if (String.IsNullOrWhiteSpace(link)) return;
+
+            Process.Start(link);
+            e.Handled = true;
+        }
+    }
+}

--- a/ARK Server Manager/PlayerProfile.xaml.cs
+++ b/ARK Server Manager/PlayerProfile.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Navigation;
 using ARK_Server_Manager.Lib.ViewModel.RCON;
+using ARK_Server_Manager.Properties;
 using ArkData;
 
 namespace ARK_Server_Manager
@@ -13,11 +15,12 @@ namespace ARK_Server_Manager
     /// </summary>
     public partial class PlayerProfile : Window
     {
-        public PlayerProfile(PlayerInfo player)
+        public PlayerProfile(PlayerInfo player, String serverFolder)
         {
             InitializeComponent();
 
             this.Player = player;
+            this.ServerFolder = serverFolder;
             this.DataContext = this;
         }
 
@@ -59,11 +62,39 @@ namespace ARK_Server_Manager
             }
         }
 
+        public String PlayerLink
+        {
+            get
+            {
+                if (String.IsNullOrWhiteSpace(ServerFolder))
+                    return null;
+
+                return String.Format("/select, {0}", Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, String.Format("{0}.arkprofile", Player.SteamId.ToString())));
+            }
+        }
+
         public String ProfileUrl
         {
             get
             {
                 return ArkDataPlayer?.ProfileUrl;
+            }
+        }
+
+        public String ServerFolder
+        {
+            get;
+            private set;
+        }
+
+        public String TribeLink
+        {
+            get
+            {
+                if (String.IsNullOrWhiteSpace(ServerFolder))
+                    return null;
+                
+                return ArkDataTribe == null ? null : String.Format("/select, {0}", Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, String.Format("{0}.arktribe", ArkDataTribe.Id.ToString())));
             }
         }
 
@@ -99,6 +130,28 @@ namespace ARK_Server_Manager
             if (String.IsNullOrWhiteSpace(link)) return;
 
             Process.Start(link);
+            e.Handled = true;
+        }
+
+        private void PlayerId_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (sender.GetType() != typeof(Hyperlink)) return;
+
+            string link = ((Hyperlink)sender).NavigateUri.ToString();
+            if (String.IsNullOrWhiteSpace(link)) return;
+
+            Process.Start("explorer.exe", link);
+            e.Handled = true;
+        }
+
+        private void TribeId_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (sender.GetType() != typeof(Hyperlink)) return;
+
+            string link = ((Hyperlink)sender).NavigateUri.ToString();
+            if (String.IsNullOrWhiteSpace(link)) return;
+
+            Process.Start("explorer.exe", link);
             e.Handled = true;
         }
     }

--- a/ARK Server Manager/RCONWindow.xaml
+++ b/ARK Server Manager/RCONWindow.xaml
@@ -116,7 +116,8 @@
                                 <MenuItem Header="Banned" IsCheckable="{Binding IsBanned}" Command="{Binding Source={StaticResource proxy}, Path=Data.BanPlayerCommand}" CommandParameter="{Binding}" />
                                 <MenuItem Header="Whitelisted" IsCheckable="{Binding IsWhitelisted}" Command="{Binding Source={StaticResource proxy}, Path=Data.WhitelistPlayerCommand}" CommandParameter="{Binding}" />
                                 <Separator/>
-                                <MenuItem Header="View Profile..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerProfileCommand}" CommandParameter="{Binding}" />
+                                <MenuItem Header="View Steam Profile..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerSteamProfileCommand}" CommandParameter="{Binding}" />
+                                <MenuItem Header="View Profile..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerProfileCommand}" CommandParameter="{Binding}"/>
                                 <MenuItem Header="View Tribe..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerTribeCommand}" CommandParameter="{Binding}"/>
                                 <MenuItem Header="Copy SteamID..." Command="{Binding Source={StaticResource proxy}, Path=Data.CopySteamIDCommand}" CommandParameter="{Binding}"/>                                
                             </ContextMenu>

--- a/ARK Server Manager/RCONWindow.xaml.cs
+++ b/ARK Server Manager/RCONWindow.xaml.cs
@@ -414,14 +414,29 @@ namespace ARK_Server_Manager
             }
         }
 
+        public ICommand ViewPlayerSteamProfileCommand
+        {
+            get
+            {
+                return new RelayCommand<PlayerInfo>(
+                    execute: (player) => { Process.Start(player.ArkData.ProfileUrl); },
+                    canExecute: (player) => player != null && !String.IsNullOrWhiteSpace(player.ArkData.ProfileUrl)
+                );
+            }
+        }
+
         public ICommand ViewPlayerProfileCommand
         {
             get
             {
                 return new RelayCommand<PlayerInfo>(
-                    execute: (player) => { Process.Start($"http://steamcommunity.com/profiles/{player.SteamId}"); },
-                    canExecute: (player) => true 
-                );
+                    execute: (player) => {
+                        var window = new PlayerProfile(player);
+                        window.Owner = this;
+                        window.ShowDialog();
+                        },
+                    canExecute: (player) => player != null
+                    );
             }
         }
 
@@ -430,10 +445,13 @@ namespace ARK_Server_Manager
             get
             {
                 return new RelayCommand<PlayerInfo>(
-                    execute: (player) => { },
-                    canExecute: (player) => false //player != null && !String.IsNullOrWhiteSpace(player.TribeName
+                    execute: (player) => {
+                        var window = new TribeProfile(player);
+                        window.Owner = this;
+                        window.ShowDialog();
+                    },
+                    canExecute: (player) => player != null && !String.IsNullOrWhiteSpace(player.TribeName)
                     );
-
             }
         }
 

--- a/ARK Server Manager/RCONWindow.xaml.cs
+++ b/ARK Server Manager/RCONWindow.xaml.cs
@@ -431,7 +431,7 @@ namespace ARK_Server_Manager
             {
                 return new RelayCommand<PlayerInfo>(
                     execute: (player) => {
-                        var window = new PlayerProfile(player);
+                        var window = new PlayerProfile(player, this.RCONParameters.InstallDirectory);
                         window.Owner = this;
                         window.ShowDialog();
                         },
@@ -446,7 +446,7 @@ namespace ARK_Server_Manager
             {
                 return new RelayCommand<PlayerInfo>(
                     execute: (player) => {
-                        var window = new TribeProfile(player);
+                        var window = new TribeProfile(player, this.RCONParameters.InstallDirectory);
                         window.Owner = this;
                         window.ShowDialog();
                     },

--- a/ARK Server Manager/ServerSettingsControl.xaml.cs
+++ b/ARK Server Manager/ServerSettingsControl.xaml.cs
@@ -293,6 +293,7 @@ namespace ARK_Server_Manager
         private void ShowCmd_Click(object sender, RoutedEventArgs e)
         {
             var cmdLine = new CommandLine(String.Format("{0} {1}", this.Runtime.GetServerExe(), this.Settings.GetServerArgs()));
+            cmdLine.Owner = Window.GetWindow(this);
             cmdLine.ShowDialog();
         }
 

--- a/ARK Server Manager/TribeProfile.xaml
+++ b/ARK Server Manager/TribeProfile.xaml
@@ -1,0 +1,81 @@
+﻿<Window x:Class="ARK_Server_Manager.TribeProfile"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:ARK_Server_Manager.Lib.ViewModel"
+        Title="{Binding WindowTitle}"
+        Width="600" ResizeMode="NoResize" SizeToContent="Height" Icon="Art/favicon.ico" WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Globalization\en-US\en-US.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <LinearGradientBrush x:Key="BeigeGradient" EndPoint="0.5,1" StartPoint="0.5,0">
+                <GradientStop Color="#FFECE1D4" Offset="1"/>
+                <GradientStop Color="#FFEAE8E6"/>
+            </LinearGradientBrush>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Background="{StaticResource BeigeGradient}">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <StackPanel Margin="10,2,10,2" CanVerticallyScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Row="0" Content="{DynamicResource Profile_NameLabel}"/>
+                <Label Grid.Row="0" Grid.Column="1" Content="{Binding Player.TribeName}" FontWeight="Bold" FontSize="13.333"/>
+                <Label Grid.Row="1" Content="{DynamicResource Profile_CreatedLabel}"/>
+                <Label Grid.Row="1" Grid.Column="1" Content="{Binding CreatedDate}"/>
+                <Label Grid.Row="2" Content="{DynamicResource Profile_UpdatedLabel}"/>
+                <Label Grid.Row="2" Grid.Column="1" Content="{Binding UpdatedDate}"/>
+            </Grid>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding ArkDataTribe.Id}"/>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_TribeOwnerLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding TribeOwner}"/>
+                </Grid>
+            </GroupBox>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeMembersSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <ListView x:Name="TribeMembersListView" ItemsSource="{Binding ArkDataTribe.Players}" Height="200" HorizontalContentAlignment="Stretch">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="{DynamicResource Profile_SteamNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding SteamName}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_CharacterNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding CharacterName}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_LevelColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding Level}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_OnlineColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding Online}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_CreatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding FileCreated}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_UpdatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding FileUpdated}"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </Grid>
+            </GroupBox>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ARK Server Manager/TribeProfile.xaml
+++ b/ARK Server Manager/TribeProfile.xaml
@@ -52,7 +52,13 @@
                         <ColumnDefinition Width="2*"/>
                     </Grid.ColumnDefinitions>
                     <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
-                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding ArkDataTribe.Id}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{DynamicResource Profile_NavigateProfile}">
+                        <Hyperlink NavigateUri="{Binding TribeLink}" RequestNavigate="TribeId_RequestNavigate">
+                           <Hyperlink.Inlines>
+                                <Run Text="{Binding ArkDataTribe.Id}"/>
+                           </Hyperlink.Inlines>
+                        </Hyperlink>
+                    </TextBlock>
                     <Label Grid.Row="1" Content="{DynamicResource Profile_TribeOwnerLabel}"/>
                     <Label Grid.Row="1" Grid.Column="1" Content="{Binding TribeOwner}"/>
                 </Grid>

--- a/ARK Server Manager/TribeProfile.xaml.cs
+++ b/ARK Server Manager/TribeProfile.xaml.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Navigation;
+using ARK_Server_Manager.Lib.ViewModel.RCON;
+using ArkData;
+
+namespace ARK_Server_Manager
+{
+    /// <summary>
+    /// Interaction logic for TribeProfile.xaml
+    /// </summary>
+    public partial class TribeProfile : Window
+    {
+        public TribeProfile(PlayerInfo player)
+        {
+            InitializeComponent();
+
+            this.Player = player;
+            this.DataContext = this;
+        }
+
+        public PlayerInfo Player
+        {
+            get;
+            private set;
+        }
+
+        public Player ArkDataPlayer
+        {
+            get
+            {
+                return Player?.ArkData;
+            }
+        }
+
+        public Tribe ArkDataTribe
+        {
+            get
+            {
+                return Player?.ArkData?.Tribe;
+            }
+        }
+
+        public String CreatedDate
+        {
+            get
+            {
+                return ArkDataTribe?.FileCreated.ToString("G");
+            }
+        }
+
+        public String TribeOwner
+        {
+            get
+            {
+                return ArkDataTribe != null && ArkDataTribe.Owner != null ? string.Format("{0} ({1})", ArkDataTribe.Owner.SteamName, ArkDataTribe.Owner.CharacterName) : null;
+            }
+        }
+
+        public String UpdatedDate
+        {
+            get
+            {
+                return ArkDataTribe?.FileUpdated.ToString("G");
+            }
+        }
+
+        public String WindowTitle
+        {
+            get
+            {
+                return String.Format("Tribe Profile - {0}", Player.TribeName);
+            }
+        }
+    }
+}

--- a/ARK Server Manager/TribeProfile.xaml.cs
+++ b/ARK Server Manager/TribeProfile.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Navigation;
@@ -13,11 +14,12 @@ namespace ARK_Server_Manager
     /// </summary>
     public partial class TribeProfile : Window
     {
-        public TribeProfile(PlayerInfo player)
+        public TribeProfile(PlayerInfo player, String serverFolder)
         {
             InitializeComponent();
 
             this.Player = player;
+            this.ServerFolder = serverFolder;
             this.DataContext = this;
         }
 
@@ -51,6 +53,23 @@ namespace ARK_Server_Manager
             }
         }
 
+        public String ServerFolder
+        {
+            get;
+            private set;
+        }
+
+        public String TribeLink
+        {
+            get
+            {
+                if (String.IsNullOrWhiteSpace(ServerFolder))
+                    return null;
+
+                return ArkDataTribe == null ? null : String.Format("/select, {0}", Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, String.Format("{0}.arktribe", ArkDataTribe.Id.ToString())));
+            }
+        }
+
         public String TribeOwner
         {
             get
@@ -73,6 +92,17 @@ namespace ARK_Server_Manager
             {
                 return String.Format("Tribe Profile - {0}", Player.TribeName);
             }
+        }
+
+        private void TribeId_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            if (sender.GetType() != typeof(Hyperlink)) return;
+
+            string link = ((Hyperlink)sender).NavigateUri.ToString();
+            if (String.IsNullOrWhiteSpace(link)) return;
+
+            Process.Start("explorer.exe", link);
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
1. BugFix - Added the owner to the commandline window, so when open and looses focus, the command line window is bought to the foreground when ASM is reselected.

As part of my server maintenance I use an application called ArkAdmin. After decompiling it I realised it is just a striped version of ArkData that shows the Player and Tribe information. So using the RCON window in ASM, I wanted to be able to view the same data.

RCONWindow changes
2. Change View Profile... menu option to View Steam Profile...
3. Added new View Profile... menu item.
4. Created a new Player Profile window - shows details about the selected player.
5. Created a new Tribe Profile window - shows details about the selected player's tribe.

NOTE: Both new windows are accessible via right-click on the player and
selecting either View Profile or View Tribe.
