### PR TITLE
RCON Window Features

### DIFF
--- a/ARK Server Manager/ARK Server Manager.csproj
+++ b/ARK Server Manager/ARK Server Manager.csproj
@@ -227,6 +227,9 @@
     <Compile Include="OpenRCON.xaml.cs">
       <DependentUpon>OpenRCON.xaml</DependentUpon>
     </Compile>
+    <Compile Include="PlayerProfile.xaml.cs">
+      <DependentUpon>PlayerProfile.xaml</DependentUpon>
+    </Compile>
     <Compile Include="RCONWindow.xaml.cs">
       <DependentUpon>RCONWindow.xaml</DependentUpon>
     </Compile>
@@ -236,6 +239,9 @@
     <Compile Include="Lib\ServerStatusWatcher.cs" />
     <Compile Include="Testing\UITests.xaml.cs">
       <DependentUpon>UITests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="TribeProfile.xaml.cs">
+      <DependentUpon>TribeProfile.xaml</DependentUpon>
     </Compile>
     <Compile Include="WPFControls\AnnotatedGlowSlider.xaml.cs">
       <DependentUpon>AnnotatedGlowSlider.xaml</DependentUpon>
@@ -266,7 +272,15 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="PlayerProfile.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Testing\UITests.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="TribeProfile.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/ARK Server Manager/Globalization/en-US/en-US.xaml
+++ b/ARK Server Manager/Globalization/en-US/en-US.xaml
@@ -527,4 +527,33 @@
     <sys:String x:Key="ServerSettings_EnableGamePlayLoggingLabel">Enable Game Play Logging</sys:String>
     <sys:String x:Key="ServerSettings_EnableGamePlayLoggingTooltip">If enabled, outputs a dated log file to \Saved folder, which will contain a timestamped kill and winners log listing steam id, steam name, character name, etc. Handy for automatic Tournament records.</sys:String>
 
+    <!-- Player/Tribe Profile Window -->
+    <sys:String x:Key="Profile_SteamSectionLabel">Steam Details</sys:String>
+    <sys:String x:Key="Profile_PlayerSectionLabel">Player Details</sys:String>
+    <sys:String x:Key="Profile_TribeSectionLabel">Tribe Details</sys:String>
+    <sys:String x:Key="Profile_TribeMembersSectionLabel">Tribe Members</sys:String>
+
+    <sys:String x:Key="Profile_IdLabel">Id:</sys:String>
+    <sys:String x:Key="Profile_NameLabel">Name:</sys:String>
+    <sys:String x:Key="Profile_OnlineLabel">Online:</sys:String>
+    <sys:String x:Key="Profile_CreatedLabel">Created:</sys:String>
+    <sys:String x:Key="Profile_UpdatedLabel">Last Updated:</sys:String>
+    <sys:String x:Key="Profile_BannedCommunityLabel">Community Banned:</sys:String>
+    <sys:String x:Key="Profile_BannedVACLabel">VAC Banned:</sys:String>
+    <sys:String x:Key="Profile_BannedVACCountLabel">Number of VAC Bans:</sys:String>
+    <sys:String x:Key="Profile_BannedVACDaysLabel">Days Since Last Ban:</sys:String>
+    <sys:String x:Key="Profile_LevelLabel">Level:</sys:String>
+    <sys:String x:Key="Profile_WhitelistedLabel">Whitelisted:</sys:String>
+    <sys:String x:Key="Profile_BannedLabel">Banned:</sys:String>
+    <sys:String x:Key="Profile_BannedGameCountLabel">Number of Game Bans:</sys:String>
+    <sys:String x:Key="Profile_TribeOwnerLabel">Owner:</sys:String>
+    <sys:String x:Key="Profile_SteamNameColumnLabel">Steam Name</sys:String>
+    <sys:String x:Key="Profile_CharacterNameColumnLabel">Character Name</sys:String>
+    <sys:String x:Key="Profile_LevelColumnLabel">Level</sys:String>
+    <sys:String x:Key="Profile_OnlineColumnLabel">Online</sys:String>
+    <sys:String x:Key="Profile_CreatedColumnLabel">Created</sys:String>
+    <sys:String x:Key="Profile_UpdatedColumnLabel">Last Updated</sys:String>
+    <sys:String x:Key="Profile_NavigateSteamProfile">Click to open the steam profile in a browser</sys:String>
+    <sys:String x:Key="Profile_NavigateProfile">Click to view the profile file in explorer</sys:String>
+    
 </Globalization:GlobalizationResourceDictionary>

--- a/ARK Server Manager/PlayerProfile.xaml
+++ b/ARK Server Manager/PlayerProfile.xaml
@@ -1,0 +1,205 @@
+﻿<Window x:Class="ARK_Server_Manager.PlayerProfile"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:ARK_Server_Manager.Lib.ViewModel"
+        xmlns:local="clr-namespace:ARK_Server_Manager"
+        Title="{Binding WindowTitle}"
+        Width="500" ResizeMode="NoResize" SizeToContent="Height" Icon="Art/favicon.ico" WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Globalization\en-US\en-US.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <LinearGradientBrush x:Key="BeigeGradient" EndPoint="0.5,1" StartPoint="0.5,0">
+                <GradientStop Color="#FFECE1D4" Offset="1"/>
+                <GradientStop Color="#FFEAE8E6"/>
+            </LinearGradientBrush>
+            <vm:NullValueConverter x:Key="NullValueConverter"/>
+            <BitmapImage x:Key="NoAvatar" UriSource="Art/NoAvatar.png" />
+            <Style x:Key="Online" TargetType="{x:Type Label}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Player.IsOnline}" Value="True">
+                        <Setter Property="Foreground" Value="Green"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Player.IsOnline}" Value="False">
+                        <Setter Property="Foreground" Value="Red"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="CommunityBanned" TargetType="{x:Type Label}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding ArkDataPlayer.CommunityBanned}" Value="False">
+                        <Setter Property="Foreground" Value="Black"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding ArkDataPlayer.CommunityBanned}" Value="True">
+                        <Setter Property="Foreground" Value="Red"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="VACBanned" TargetType="{x:Type Label}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding ArkDataPlayer.VACBanned}" Value="False">
+                        <Setter Property="Foreground" Value="Black"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding ArkDataPlayer.VACBanned}" Value="True">
+                        <Setter Property="Foreground" Value="Red"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="Banned" TargetType="{x:Type Label}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Player.IsBanned}" Value="False">
+                        <Setter Property="Foreground" Value="Black"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Player.IsBanned}" Value="True">
+                        <Setter Property="Foreground" Value="Red"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="Whitelisted" TargetType="{x:Type Label}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding Player.IsWhitelisted}" Value="True">
+                        <Setter Property="Foreground" Value="Blue"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding Player.IsWhitelisted}" Value="False">
+                        <Setter Property="Foreground" Value="Black"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Background="{StaticResource BeigeGradient}">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <StackPanel Margin="10,2,10,2" CanVerticallyScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Row="0" Content="{DynamicResource Profile_NameLabel}"/>
+                <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333" ToolTip="{DynamicResource Profile_NavigateSteamProfile}">
+                    <Hyperlink NavigateUri="{Binding ProfileLink}" Command="{Binding DirectLinkCommand}" CommandParameter="{Binding ProfileLink}">
+                       <Hyperlink.Inlines>
+                            <Run Text="{Binding Player.SteamName}"/>
+                       </Hyperlink.Inlines>
+                    </Hyperlink>
+                </TextBlock>
+                <Image Grid.Row="0" Grid.Column="2" Grid.RowSpan="4" VerticalAlignment="Top" HorizontalAlignment="Right" Source="{Binding Player.AvatarImage, Converter={StaticResource ResourceKey=NullValueConverter}, ConverterParameter={StaticResource ResourceKey=NoAvatar}}" Width="48" Height="48" Stretch="Uniform"/>
+                <Label Grid.Row="1" Content="{DynamicResource Profile_OnlineLabel}"/>
+                <Label Grid.Row="1" Grid.Column="1" Content="{Binding Player.IsOnline}" Style="{DynamicResource Online}"/>
+                <Label Grid.Row="2" Content="{DynamicResource Profile_CreatedLabel}"/>
+                <Label Grid.Row="2" Grid.Column="1" Content="{Binding CreatedDate}"/>
+                <Label Grid.Row="3" Content="{DynamicResource Profile_UpdatedLabel}"/>
+                <Label Grid.Row="3" Grid.Column="1" Content="{Binding UpdatedDate}"/>
+            </Grid>
+            <GroupBox HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_SteamSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <Label Grid.Row="0" Grid.Column="1" Content="{Binding Player.SteamId}"/>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_BannedCommunityLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataPlayer.CommunityBanned}" Style="{DynamicResource CommunityBanned}"/>
+                    <Label Grid.Row="2" Content="{DynamicResource Profile_BannedVACLabel}"/>
+                    <Label Grid.Row="2" Grid.Column="1" Content="{Binding ArkDataPlayer.VACBanned}" Style="{DynamicResource VACBanned}"/>
+                    <Label Grid.Row="3" Content="{DynamicResource Profile_BannedVACCountLabel}"/>
+                    <Label Grid.Row="3" Grid.Column="1" Content="{Binding ArkDataPlayer.NumberOfVACBans}"/>
+                    <Label Grid.Row="4" Content="{DynamicResource Profile_BannedVACDaysLabel}"/>
+                    <Label Grid.Row="4" Grid.Column="1" Content="{Binding ArkDataPlayer.DaysSinceLastBan}"/>
+                </Grid>
+            </GroupBox>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_PlayerSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{DynamicResource Profile_NavigateProfile}">
+                        <Hyperlink NavigateUri="{Binding PlayerLink}" Command="{Binding ExplorerLinkCommand}" CommandParameter="{Binding PlayerLink}">
+                           <Hyperlink.Inlines>
+                                <Run Text="{Binding ArkDataPlayer.Id}"/>
+                           </Hyperlink.Inlines>
+                        </Hyperlink>
+                    </TextBlock>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_NameLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataPlayer.CharacterName}"/>
+                    <Label Grid.Row="2" Content="{DynamicResource Profile_LevelLabel}"/>
+                    <Label Grid.Row="2" Grid.Column="1" Content="{Binding ArkDataPlayer.Level}"/>
+                    <Label Grid.Row="3" Content="{DynamicResource Profile_WhitelistedLabel}"/>
+                    <Label Grid.Row="3" Grid.Column="1" Content="{Binding Player.IsWhitelisted}" Style="{DynamicResource Whitelisted}"/>
+                    <Label Grid.Row="4" Content="{DynamicResource Profile_BannedLabel}"/>
+                    <Label Grid.Row="4" Grid.Column="1" Content="{Binding Player.IsBanned}" Style="{DynamicResource Banned}"/>
+                    <Label Grid.Row="5" Content="{DynamicResource Profile_BannedGameCountLabel}"/>
+                    <Label Grid.Row="5" Grid.Column="1" Content="{Binding ArkDataPlayer.NumberOfGameBans}"/>
+                </Grid>
+            </GroupBox>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{DynamicResource Profile_NavigateProfile}">
+                        <Hyperlink NavigateUri="{Binding TribeLink}" Command="{Binding ExplorerLinkCommand}" CommandParameter="{Binding TribeLink}">
+                           <Hyperlink.Inlines>
+                                <Run Text="{Binding ArkDataTribe.Id}"/>
+                           </Hyperlink.Inlines>
+                        </Hyperlink>
+                    </TextBlock>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_NameLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding ArkDataTribe.Name}"/>
+                    <Label Grid.Row="2" Content="{DynamicResource Profile_TribeOwnerLabel}"/>
+                    <Label Grid.Row="2" Grid.Column="1" Content="{Binding TribeOwner}"/>
+                </Grid>
+            </GroupBox>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ARK Server Manager/PlayerProfile.xaml.cs
+++ b/ARK Server Manager/PlayerProfile.xaml.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using ARK_Server_Manager.Lib.ViewModel;
+using ARK_Server_Manager.Lib.ViewModel.RCON;
+using ArkData;
+
+namespace ARK_Server_Manager
+{
+    /// <summary>
+    /// Interaction logic for PlayerProfile.xaml
+    /// </summary>
+    public partial class PlayerProfile : Window
+    {
+        public PlayerProfile(PlayerInfo player, String serverFolder)
+        {
+            InitializeComponent();
+
+            this.Player = player;
+            this.ServerFolder = serverFolder;
+            this.DataContext = this;
+        }
+
+        public PlayerInfo Player
+        {
+            get;
+            private set;
+        }
+
+        public String ServerFolder
+        {
+            get;
+            private set;
+        }
+
+        public Player ArkDataPlayer => Player?.ArkData;
+
+        public Tribe ArkDataTribe => Player?.ArkData?.Tribe;
+
+        public String CreatedDate => ArkDataPlayer?.FileCreated.ToString("G");
+
+        public Boolean IsTribeOwner => ArkDataPlayer != null && ArkDataTribe != null && ArkDataTribe.OwnerId == ArkDataPlayer.Id;
+
+        public String PlayerLink => String.IsNullOrWhiteSpace(ServerFolder) ? null : $"/select, {Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, $"{Player.SteamId}.arkprofile")}";
+
+        public String ProfileLink => ArkDataPlayer?.ProfileUrl;
+
+        public String TribeLink => String.IsNullOrWhiteSpace(ServerFolder) || ArkDataTribe == null ? null : $"/select, {Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, $"{ArkDataTribe.Id}.arktribe")}";
+
+        public String TribeOwner => ArkDataTribe != null && ArkDataTribe.Owner != null ? $"{ArkDataTribe.Owner.SteamName} ({ArkDataTribe.Owner.CharacterName})" : null;
+
+        public String UpdatedDate => ArkDataPlayer?.FileUpdated.ToString("G");
+
+        public String WindowTitle => $"Player Profile - {Player.SteamName}";
+
+        public ICommand DirectLinkCommand
+        {
+            get
+            {
+                return new RelayCommand<String>(
+                    execute: (action) =>
+                    {
+                        if (String.IsNullOrWhiteSpace(action)) return;
+                        Process.Start(action);
+                    },
+                    canExecute: (action) => true
+                );
+            }
+        }
+
+        public ICommand ExplorerLinkCommand
+        {
+            get
+            {
+                return new RelayCommand<String>(
+                    execute: (action) =>
+                    {
+                        if (String.IsNullOrWhiteSpace(action)) return;
+                        Process.Start("explorer.exe", action);
+                    },
+                    canExecute: (action) => true
+                );
+            }
+        }
+    }
+}

--- a/ARK Server Manager/RCONWindow.xaml
+++ b/ARK Server Manager/RCONWindow.xaml
@@ -116,6 +116,7 @@
                                 <MenuItem Header="Banned" IsCheckable="{Binding IsBanned}" Command="{Binding Source={StaticResource proxy}, Path=Data.BanPlayerCommand}" CommandParameter="{Binding}" />
                                 <MenuItem Header="Whitelisted" IsCheckable="{Binding IsWhitelisted}" Command="{Binding Source={StaticResource proxy}, Path=Data.WhitelistPlayerCommand}" CommandParameter="{Binding}" />
                                 <Separator/>
+                                <MenuItem Header="View Steam Profile..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerSteamProfileCommand}" CommandParameter="{Binding}" />
                                 <MenuItem Header="View Profile..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerProfileCommand}" CommandParameter="{Binding}" />
                                 <MenuItem Header="View Tribe..." Command="{Binding Source={StaticResource proxy}, Path=Data.ViewPlayerTribeCommand}" CommandParameter="{Binding}"/>
                                 <MenuItem Header="Copy SteamID..." Command="{Binding Source={StaticResource proxy}, Path=Data.CopySteamIDCommand}" CommandParameter="{Binding}"/>                                

--- a/ARK Server Manager/RCONWindow.xaml.cs
+++ b/ARK Server Manager/RCONWindow.xaml.cs
@@ -414,14 +414,29 @@ namespace ARK_Server_Manager
             }
         }
 
+        public ICommand ViewPlayerSteamProfileCommand
+        {
+            get
+            {
+                return new RelayCommand<PlayerInfo>(
+                    execute: (player) => { Process.Start(player.ArkData.ProfileUrl); },
+                    canExecute: (player) => player != null && !String.IsNullOrWhiteSpace(player.ArkData.ProfileUrl)
+                );
+            }
+        }
+
         public ICommand ViewPlayerProfileCommand
         {
             get
             {
                 return new RelayCommand<PlayerInfo>(
-                    execute: (player) => { Process.Start($"http://steamcommunity.com/profiles/{player.SteamId}"); },
-                    canExecute: (player) => true 
-                );
+                    execute: (player) => {
+                        var window = new PlayerProfile(player, this.RCONParameters.InstallDirectory);
+                        window.Owner = this;
+                        window.ShowDialog();
+                    },
+                    canExecute: (player) => player != null
+                    );
             }
         }
 
@@ -430,10 +445,13 @@ namespace ARK_Server_Manager
             get
             {
                 return new RelayCommand<PlayerInfo>(
-                    execute: (player) => { },
-                    canExecute: (player) => false //player != null && !String.IsNullOrWhiteSpace(player.TribeName
+                    execute: (player) => {
+                        var window = new TribeProfile(player, this.RCONParameters.InstallDirectory);
+                        window.Owner = this;
+                        window.ShowDialog();
+                    },
+                    canExecute: (player) => player != null && !String.IsNullOrWhiteSpace(player.TribeName)
                     );
-
             }
         }
 

--- a/ARK Server Manager/RCONWindow.xaml.cs
+++ b/ARK Server Manager/RCONWindow.xaml.cs
@@ -446,7 +446,7 @@ namespace ARK_Server_Manager
             {
                 return new RelayCommand<PlayerInfo>(
                     execute: (player) => {
-                        var window = new TribeProfile(player, this.RCONParameters.InstallDirectory);
+                        var window = new TribeProfile(player, this.ServerRCON.Players, this.RCONParameters.InstallDirectory);
                         window.Owner = this;
                         window.ShowDialog();
                     },

--- a/ARK Server Manager/RCONWindow.xaml.cs
+++ b/ARK Server Manager/RCONWindow.xaml.cs
@@ -420,7 +420,7 @@ namespace ARK_Server_Manager
             {
                 return new RelayCommand<PlayerInfo>(
                     execute: (player) => { Process.Start(player.ArkData.ProfileUrl); },
-                    canExecute: (player) => player != null && !String.IsNullOrWhiteSpace(player.ArkData.ProfileUrl)
+                    canExecute: (player) => player != null && player.ArkData != null && !String.IsNullOrWhiteSpace(player.ArkData.ProfileUrl)
                 );
             }
         }
@@ -435,7 +435,7 @@ namespace ARK_Server_Manager
                         window.Owner = this;
                         window.ShowDialog();
                     },
-                    canExecute: (player) => player != null
+                    canExecute: (player) => player != null && player.ArkData != null
                     );
             }
         }
@@ -450,7 +450,7 @@ namespace ARK_Server_Manager
                         window.Owner = this;
                         window.ShowDialog();
                     },
-                    canExecute: (player) => player != null && !String.IsNullOrWhiteSpace(player.TribeName)
+                    canExecute: (player) => player != null && player.ArkData != null && !String.IsNullOrWhiteSpace(player.TribeName)
                     );
             }
         }

--- a/ARK Server Manager/ServerSettingsControl.xaml.cs
+++ b/ARK Server Manager/ServerSettingsControl.xaml.cs
@@ -334,6 +334,7 @@ namespace ARK_Server_Manager
         private void ShowCmd_Click(object sender, RoutedEventArgs e)
         {
             var cmdLine = new CommandLine(String.Format("{0} {1}", this.Runtime.GetServerExe(), this.Settings.GetServerArgs()));
+            cmdLine.Owner = Window.GetWindow(this);
             cmdLine.ShowDialog();
         }
 

--- a/ARK Server Manager/TribeProfile.xaml
+++ b/ARK Server Manager/TribeProfile.xaml
@@ -1,0 +1,87 @@
+﻿<Window x:Class="ARK_Server_Manager.TribeProfile"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:ARK_Server_Manager.Lib.ViewModel"
+        Title="{Binding WindowTitle}"
+        Width="600" ResizeMode="NoResize" SizeToContent="Height" Icon="Art/favicon.ico" WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Globalization\en-US\en-US.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <LinearGradientBrush x:Key="BeigeGradient" EndPoint="0.5,1" StartPoint="0.5,0">
+                <GradientStop Color="#FFECE1D4" Offset="1"/>
+                <GradientStop Color="#FFEAE8E6"/>
+            </LinearGradientBrush>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid Background="{StaticResource BeigeGradient}">
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <StackPanel Margin="10,2,10,2" CanVerticallyScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Label Grid.Row="0" Content="{DynamicResource Profile_NameLabel}"/>
+                <Label Grid.Row="0" Grid.Column="1" Content="{Binding Player.TribeName}" FontWeight="Bold" FontSize="13.333"/>
+                <Label Grid.Row="1" Content="{DynamicResource Profile_CreatedLabel}"/>
+                <Label Grid.Row="1" Grid.Column="1" Content="{Binding CreatedDate}"/>
+                <Label Grid.Row="2" Content="{DynamicResource Profile_UpdatedLabel}"/>
+                <Label Grid.Row="2" Grid.Column="1" Content="{Binding UpdatedDate}"/>
+            </Grid>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="2*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Content="{DynamicResource Profile_IdLabel}"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" ToolTip="{DynamicResource Profile_NavigateProfile}">
+                        <Hyperlink NavigateUri="{Binding TribeLink}" Command="{Binding ExplorerLinkCommand}" CommandParameter="{Binding TribeLink}">
+                           <Hyperlink.Inlines>
+                                <Run Text="{Binding ArkDataTribe.Id}"/>
+                           </Hyperlink.Inlines>
+                        </Hyperlink>
+                    </TextBlock>
+                    <Label Grid.Row="1" Content="{DynamicResource Profile_TribeOwnerLabel}"/>
+                    <Label Grid.Row="1" Grid.Column="1" Content="{Binding TribeOwner}"/>
+                </Grid>
+            </GroupBox>
+            <GroupBox  HorizontalAlignment="Stretch">
+                <GroupBox.Header>
+                    <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeMembersSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
+                </GroupBox.Header>
+                <Grid>
+                    <ListView x:Name="TribeMembersListView" ItemsSource="{Binding ArkDataTribe.Players}" Height="200" HorizontalContentAlignment="Stretch">
+                        <ListView.View>
+                            <GridView>
+                                <GridViewColumn Header="{DynamicResource Profile_SteamNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding SteamName}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_CharacterNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding CharacterName}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_LevelColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding Level}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_OnlineColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding Online}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_CreatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding FileCreated}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_UpdatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding FileUpdated}"/>
+                            </GridView>
+                        </ListView.View>
+                    </ListView>
+                </Grid>
+            </GroupBox>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/ARK Server Manager/TribeProfile.xaml
+++ b/ARK Server Manager/TribeProfile.xaml
@@ -13,6 +13,14 @@
                 <GradientStop Color="#FFECE1D4" Offset="1"/>
                 <GradientStop Color="#FFEAE8E6"/>
             </LinearGradientBrush>
+            <Style x:Key="OnlineListViewItemStyle" TargetType="{x:Type ListViewItem}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding IsOnline}" Value="True">
+                        <Setter Property="Foreground" Value="Green"/>
+                        <Setter Property="FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
     <Grid Background="{StaticResource BeigeGradient}">
@@ -68,15 +76,15 @@
                     <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="{DynamicResource Profile_TribeMembersSectionLabel}" VerticalAlignment="Center" FontWeight="Bold" FontSize="13.333"/>
                 </GroupBox.Header>
                 <Grid>
-                    <ListView x:Name="TribeMembersListView" ItemsSource="{Binding ArkDataTribe.Players}" Height="200" HorizontalContentAlignment="Stretch">
+                    <ListView x:Name="TribeMembersListView" ItemsSource="{Binding TribePlayers}" Height="200" HorizontalContentAlignment="Stretch" ItemContainerStyle="{DynamicResource OnlineListViewItemStyle}">
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="{DynamicResource Profile_SteamNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding SteamName}"/>
-                                <GridViewColumn Header="{DynamicResource Profile_CharacterNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding CharacterName}"/>
-                                <GridViewColumn Header="{DynamicResource Profile_LevelColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding Level}"/>
-                                <GridViewColumn Header="{DynamicResource Profile_OnlineColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding Online}"/>
-                                <GridViewColumn Header="{DynamicResource Profile_CreatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding FileCreated}"/>
-                                <GridViewColumn Header="{DynamicResource Profile_UpdatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding FileUpdated}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_CharacterNameColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding ArkData.CharacterName}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_LevelColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding ArkData.Level}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_OnlineColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding IsOnline}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_CreatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding ArkData.FileCreated}"/>
+                                <GridViewColumn Header="{DynamicResource Profile_UpdatedColumnLabel}" Width="Auto" DisplayMemberBinding="{Binding ArkData.FileUpdated}"/>
                             </GridView>
                         </ListView.View>
                     </ListView>

--- a/ARK Server Manager/TribeProfile.xaml.cs
+++ b/ARK Server Manager/TribeProfile.xaml.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using ARK_Server_Manager.Lib.ViewModel;
+using ARK_Server_Manager.Lib.ViewModel.RCON;
+using ArkData;
+
+namespace ARK_Server_Manager
+{
+    /// <summary>
+    /// Interaction logic for TribeProfile.xaml
+    /// </summary>
+    public partial class TribeProfile : Window
+    {
+        public TribeProfile(PlayerInfo player, String serverFolder)
+        {
+            InitializeComponent();
+
+            this.Player = player;
+            this.ServerFolder = serverFolder;
+            this.DataContext = this;
+        }
+
+        public PlayerInfo Player
+        {
+            get;
+            private set;
+        }
+
+        public String ServerFolder
+        {
+            get;
+            private set;
+        }
+
+        public Player ArkDataPlayer => Player?.ArkData;
+
+        public Tribe ArkDataTribe => Player?.ArkData?.Tribe;
+
+        public String CreatedDate => ArkDataTribe?.FileCreated.ToString("G");
+
+        public String TribeLink => String.IsNullOrWhiteSpace(ServerFolder) || ArkDataTribe == null ? null : $"/select, {Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, $"{ArkDataTribe.Id}.arktribe")}";
+
+        public String TribeOwner => ArkDataTribe != null && ArkDataTribe.Owner != null ? string.Format("{0} ({1})", ArkDataTribe.Owner.SteamName, ArkDataTribe.Owner.CharacterName) : null;
+
+        public String UpdatedDate => ArkDataTribe?.FileUpdated.ToString("G");
+
+        public String WindowTitle => $"Tribe Profile - {Player.TribeName}";
+
+        public ICommand ExplorerLinkCommand
+        {
+            get
+            {
+                return new RelayCommand<String>(
+                    execute: (action) =>
+                    {
+                        if (String.IsNullOrWhiteSpace(action)) return;
+                        Process.Start("explorer.exe", action);
+                    },
+                    canExecute: (action) => true
+                );
+            }
+        }
+    }
+}

--- a/ARK Server Manager/TribeProfile.xaml.cs
+++ b/ARK Server Manager/TribeProfile.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using ARK_Server_Manager.Lib.ViewModel;
@@ -14,16 +16,23 @@ namespace ARK_Server_Manager
     /// </summary>
     public partial class TribeProfile : Window
     {
-        public TribeProfile(PlayerInfo player, String serverFolder)
+        public TribeProfile(PlayerInfo player, ICollection<PlayerInfo> players, String serverFolder)
         {
             InitializeComponent();
 
             this.Player = player;
+            this.Players = players;
             this.ServerFolder = serverFolder;
             this.DataContext = this;
         }
 
         public PlayerInfo Player
+        {
+            get;
+            private set;
+        }
+
+        public ICollection<PlayerInfo> Players
         {
             get;
             private set;
@@ -44,6 +53,23 @@ namespace ARK_Server_Manager
         public String TribeLink => String.IsNullOrWhiteSpace(ServerFolder) || ArkDataTribe == null ? null : $"/select, {Path.Combine(ServerFolder, Config.Default.SavedArksRelativePath, $"{ArkDataTribe.Id}.arktribe")}";
 
         public String TribeOwner => ArkDataTribe != null && ArkDataTribe.Owner != null ? string.Format("{0} ({1})", ArkDataTribe.Owner.SteamName, ArkDataTribe.Owner.CharacterName) : null;
+
+        public ICollection<PlayerInfo> TribePlayers
+        {
+            get
+            {
+                if (ArkDataTribe == null) return null;
+
+                ICollection<PlayerInfo> players = new List<PlayerInfo>();
+                foreach (var tribePlayer in ArkDataTribe.Players)
+                {
+                    var player = Players.FirstOrDefault(p => p.SteamId.ToString() == tribePlayer.SteamId);
+                    if (player != null)
+                        players.Add(player);
+                }
+                return players;
+            }
+        }
 
         public String UpdatedDate => ArkDataTribe?.FileUpdated.ToString("G");
 


### PR DESCRIPTION
NOTE: I have implemented all the changes from the previous pull request.

BugFix
1. Added the owner to the commandline window, so when open and looses focus, the command line window is bought to the foreground when ASM is reselected.

RCONWindow changes
1. Change View Profile... menu option to View Steam Profile...
2. Added new View Profile... menu item.
3. Created a new Player Profile window - shows details about the selected player.
4. Created a new Tribe Profile window - shows details about the selected player's tribe.

NOTE: Both new windows are accessible via right-click on the player and selecting either View Profile or View Tribe.
