### PR TITLE
FlyingAnt_Character_BP_C Reversal

### DIFF
--- a/ARK Server Manager/Lib/GameData.cs
+++ b/ARK Server Manager/Lib/GameData.cs
@@ -17,7 +17,7 @@ namespace ARK_Server_Manager.Lib
             {
                 new DinoSpawn { ClassName="Angler_Character_BP_C",          DinoNameTag="Angler",          DinoName="Angler Fish",         CommonName="Angler",              SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
                 new DinoSpawn { ClassName="Ankylo_Character_BP_C",          DinoNameTag="Anky",            DinoName="Ankylosaurus",        CommonName="Ankylo",              SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
-                new DinoSpawn { ClassName="Ant_Character_BP_C",             DinoNameTag="Ant",             DinoName="Titanomyrma",         CommonName="Titanomyrma",         SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
+                new DinoSpawn { ClassName="Ant_Character_BP_C",             DinoNameTag="Ant",             DinoName="Titanomyrma",         CommonName="Titanomyrma Drone",   SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
                 new DinoSpawn { ClassName="Argent_Character_BP_C",          DinoNameTag="Argent",          DinoName="Argentavis",          CommonName="Argentavis",          SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
                 new DinoSpawn { ClassName="Bat_Character_BP_C",             DinoNameTag="Bat",             DinoName="Onychonycteris",      CommonName="Onyc",                SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
                 new DinoSpawn { ClassName="BigFoot_Character_BP_C",         DinoNameTag="Bigfoot",         DinoName="Gigantopithecus",     CommonName="Gigantopithecus",     SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
@@ -72,9 +72,9 @@ namespace ARK_Server_Manager.Lib
                 new DinoSpawn { ClassName="Turtle_Character_BP_C",          DinoNameTag="Turtle",          DinoName="Carbonemys",          CommonName="Carbonemys",          SpawnWeightMultiplier=0.1f, OverrideSpawnLimitPercentage=true, SpawnLimitPercentage=1.0f },
             };
 
-        public static string NameTagForClass(string entry) => dinoSpawns.First(d => d.ClassName == entry).DinoNameTag;
+        public static string NameTagForClass(string entry) => entry == "FlyingAnt_Character_BP_C" ? null : dinoSpawns.First(d => d.ClassName == entry).DinoNameTag;
 
-        public static string FriendlyNameForClass(string entry) => dinoSpawns.First(d => d.ClassName == entry).CommonName;
+        public static string FriendlyNameForClass(string entry) => entry == "FlyingAnt_Character_BP_C" ? "Titanomyrma Soldier" : dinoSpawns.First(d => d.ClassName == entry).CommonName;
 
         public static IEnumerable<DinoSpawn> GetDinoSpawns() => dinoSpawns.Select(d => d.Duplicate<DinoSpawn>());
 
@@ -134,14 +134,16 @@ namespace ARK_Server_Manager.Lib
             new ClassMultiplier { ClassName="Toad_Character_BP_C",          Multiplier=1.0f },
             new ClassMultiplier { ClassName="Trike_Character_BP_C",         Multiplier=1.0f },
             new ClassMultiplier { ClassName="Trilobite_Character_C",        Multiplier=1.0f },
-            new ClassMultiplier { ClassName="Turtle_Character_BP_C",        Multiplier=1.0f }
-        };
+            new ClassMultiplier { ClassName="Turtle_Character_BP_C",        Multiplier=1.0f },
 
-        public static IEnumerable<ClassMultiplier> GetStandardDinoMultipliers() => standardDinoMultipliers.Select(d => d.Duplicate<ClassMultiplier>());
+            new ClassMultiplier { ClassName="FlyingAnt_Character_BP_C",     Multiplier=1.0f },
+        };
 
         public static IEnumerable<string> GetDinoClasses() => standardDinoMultipliers.Select(d => d.ClassName);
 
         public static IEnumerable<NPCReplacement> GetNPCReplacements() => standardDinoMultipliers.Select(d => new NPCReplacement() { FromClassName = d.ClassName, ToClassName = d.ClassName });
+
+        public static IEnumerable<ClassMultiplier> GetStandardDinoMultipliers() => standardDinoMultipliers.Select(d => d.Duplicate<ClassMultiplier>());
 
         private static readonly ClassMultiplier[] standardResourceMultipliers = new ClassMultiplier[]
         {

--- a/ARK Server Manager/ServerSettingsControl.xaml
+++ b/ARK Server Manager/ServerSettingsControl.xaml
@@ -308,6 +308,13 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+            <Style x:Key="DinoSpawnGridCellStyle" TargetType="{x:Type DataGridCell}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding CanSetSpawnMultipliers}" Value="False">
+                        <Setter Property="IsEnabled" Value="False" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
             <LinearGradientBrush x:Key="BeigeGradient" EndPoint="0.5,1" StartPoint="0.5,0">
                 <GradientStop Color="#FFECE1D4" Offset="1"/>
                 <GradientStop Color="#FFEAE8E6"/>
@@ -1376,23 +1383,49 @@
                                             </Button>
                                         </StackPanel>
                                     </GroupBox.Header>
-                                    <DataGrid Name="DinoSettingsGrid" ItemsSource="{Binding DinoSettings}" AutoGenerateColumns="False" Height="400" FrozenColumnCount="1">
+                                    <DataGrid Name="DinoSettingsGrid" ItemsSource="{Binding DinoSettings}" AutoGenerateColumns="False" Height="400" FrozenColumnCount="1" CanUserAddRows="False">
                                         <DataGrid.Columns>
-                                            <DataGridTextColumn Binding="{Binding FriendlyName, Mode=TwoWay}" Header="{DynamicResource ServerSettings_NameColumnLabel}"/>
-                                            <DataGridCheckBoxColumn Binding="{Binding CanSpawn, Mode=TwoWay}" Header="{DynamicResource ServerSettings_SpawnableColumnLabel}"/>
-                                            <DataGridCheckBoxColumn Binding="{Binding CanTame, Mode=TwoWay}" Header="{DynamicResource ServerSettings_TameableColumnLabel}"/>
-                                            <DataGridComboBoxColumn ItemsSource="{StaticResource BaseDinoSettings}"
-                                                                    SelectedValueBinding="{Binding ReplacementClass, Mode=TwoWay}" 
-                                                                    SelectedValuePath="ClassName"                                                                     
-                                                                    DisplayMemberPath="FriendlyName" 
-                                                                    Header="{DynamicResource ServerSettings_ReplacementColumnLabel}"/>
-                                            <DataGridTextColumn Binding="{Binding SpawnWeightMultiplier, Mode=TwoWay}" Header="{DynamicResource ServerSettings_SpawnWeightColumnLabel}" Visibility="{Binding Source={x:Reference EditSpawnsCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <DataGridCheckBoxColumn Binding="{Binding OverrideSpawnLimitPercentage, Mode=TwoWay}" Header="{DynamicResource ServerSettings_OverrideLimitColumnLabel}" Visibility="{Binding Source={x:Reference EditSpawnsCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <DataGridTextColumn Binding="{Binding SpawnLimitPercentage, Mode=TwoWay}" Header="{DynamicResource ServerSettings_SpawnLimitColumnLabel}" Visibility="{Binding Source={x:Reference EditSpawnsCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <DataGridTextColumn Binding="{Binding TamedDamageMultiplier, Mode=TwoWay}" Header="{DynamicResource ServerSettings_TamedDamageColumnLabel}" Visibility="{Binding Source={x:Reference EditTamedDamageCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <DataGridTextColumn Binding="{Binding TamedResistanceMultiplier, Mode=TwoWay}" Header="{DynamicResource ServerSettings_TamedResistanceColumnLabel}" Visibility="{Binding Source={x:Reference EditTamedResistanceCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <DataGridTextColumn Binding="{Binding WildDamageMultiplier, Mode=TwoWay}" Header="{DynamicResource ServerSettings_WildDamageColumnLabel}" Visibility="{Binding Source={x:Reference EditWildDamageCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-                                            <DataGridTextColumn Binding="{Binding WildResistanceMultiplier, Mode=TwoWay}" Header="{DynamicResource ServerSettings_WildResistanceColumnLabel}" Visibility="{Binding Source={x:Reference EditWildResistanceCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            <DataGridTextColumn     Binding="{Binding FriendlyName, Mode=TwoWay}"                 Header="{DynamicResource ServerSettings_NameColumnLabel}"/>
+                                            <DataGridCheckBoxColumn Binding="{Binding CanSpawn, Mode=TwoWay}"                     Header="{DynamicResource ServerSettings_SpawnableColumnLabel}"/>
+                                            <DataGridCheckBoxColumn Binding="{Binding CanTame, Mode=TwoWay}"                      Header="{DynamicResource ServerSettings_TameableColumnLabel}"/>
+                                            <DataGridComboBoxColumn ItemsSource="{StaticResource BaseDinoSettings}" SelectedValueBinding="{Binding ReplacementClass, Mode=TwoWay}" SelectedValuePath="ClassName" DisplayMemberPath="FriendlyName" Header="{DynamicResource ServerSettings_ReplacementColumnLabel}"/>
+                                            <DataGridTextColumn     Binding="{Binding SpawnWeightMultiplier, Mode=TwoWay}"        Header="{DynamicResource ServerSettings_SpawnWeightColumnLabel}" Visibility="{Binding Source={x:Reference EditSpawnsCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <DataGridTextColumn.CellStyle>
+                                                    <Style TargetType="{x:Type DataGridCell}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding CanSetSpawnMultipliers}" Value="False">
+                                                                <Setter Property="Visibility" Value="Hidden" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </DataGridTextColumn.CellStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridCheckBoxColumn Binding="{Binding OverrideSpawnLimitPercentage, Mode=TwoWay}" Header="{DynamicResource ServerSettings_OverrideLimitColumnLabel}" Visibility="{Binding Source={x:Reference EditSpawnsCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <DataGridCheckBoxColumn.CellStyle>
+                                                    <Style TargetType="{x:Type DataGridCell}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding CanSetSpawnMultipliers}" Value="False">
+                                                                <Setter Property="Visibility" Value="Hidden" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </DataGridCheckBoxColumn.CellStyle>
+                                            </DataGridCheckBoxColumn>
+                                            <DataGridTextColumn     Binding="{Binding SpawnLimitPercentage, Mode=TwoWay}"         Header="{DynamicResource ServerSettings_SpawnLimitColumnLabel}" Visibility="{Binding Source={x:Reference EditSpawnsCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <DataGridTextColumn.CellStyle>
+                                                    <Style TargetType="{x:Type DataGridCell}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding CanSetSpawnMultipliers}" Value="False">
+                                                                <Setter Property="Visibility" Value="Hidden" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </DataGridTextColumn.CellStyle>
+                                            </DataGridTextColumn>
+                                            <DataGridTextColumn     Binding="{Binding TamedDamageMultiplier, Mode=TwoWay}"        Header="{DynamicResource ServerSettings_TamedDamageColumnLabel}" Visibility="{Binding Source={x:Reference EditTamedDamageCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            <DataGridTextColumn     Binding="{Binding TamedResistanceMultiplier, Mode=TwoWay}"    Header="{DynamicResource ServerSettings_TamedResistanceColumnLabel}" Visibility="{Binding Source={x:Reference EditTamedResistanceCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            <DataGridTextColumn     Binding="{Binding WildDamageMultiplier, Mode=TwoWay}"         Header="{DynamicResource ServerSettings_WildDamageColumnLabel}" Visibility="{Binding Source={x:Reference EditWildDamageCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            <DataGridTextColumn     Binding="{Binding WildResistanceMultiplier, Mode=TwoWay}"     Header="{DynamicResource ServerSettings_WildResistanceColumnLabel}" Visibility="{Binding Source={x:Reference EditWildResistanceCheckbox}, Path=IsChecked, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                                         </DataGrid.Columns>
                                     </DataGrid>
                                 </GroupBox>


### PR DESCRIPTION
1. Have reimplemented the FlyingAnt_Character_BP_C class.
2. The dino settings grid now hides the spawn values so they cannot be
   set for dino entry that have CanSetSpawnMultipliers = false.
