### PR TITLE
Clear If Default (Please Review and Comment)

### DIFF
--- a/ARK Server Manager/Lib/Model/ServerProfile.cs
+++ b/ARK Server Manager/Lib/Model/ServerProfile.cs
@@ -186,7 +186,7 @@ namespace ARK_Server_Manager.Lib
         public static readonly DependencyProperty CustomRecipeEffectivenessMultiplierProperty = DependencyProperty.Register(nameof(CustomRecipeEffectivenessMultiplier), typeof(float), typeof(ServerProfile), new PropertyMetadata(1.0f));
         public static readonly DependencyProperty CustomRecipeSkillMultiplierProperty = DependencyProperty.Register(nameof(CustomRecipeSkillMultiplier), typeof(float), typeof(ServerProfile), new PropertyMetadata(1.0f));
 
-        [IniFileEntry(IniFiles.GameUserSettings, IniFileSections.ServerSettings, "GlobalVoiceChat")]
+        [IniFileEntry(IniFiles.GameUserSettings, IniFileSections.ServerSettings, "GlobalVoiceChat", ClearIfDefault = true)]
         public bool EnableGlobalVoiceChat
         {
             get { return (bool)GetValue(EnableGlobalVoiceChatProperty); }


### PR DESCRIPTION
1. Added a new attribute to clear the ini file value if set to the default.

What I am hoping to achieve is a smaller ini file that only contains the properties that have changed from the default, rather than writing every property to the ini file.

In this submission I have only added the attribute to one property as proof of concept. But I would like to extend it to ALL necessary properties. **The code in question is between lines 180 - 190 of the SystemIniFile.cs file.**

My main concern is the retrieval of the DependancyProperty. Is there a better way to do this?
