### PR TITLE
Disable validate on automatic update check.

### DIFF
--- a/ARK Server Manager/Lib/ServerUpdater/ServerApp.cs
+++ b/ARK Server Manager/Lib/ServerUpdater/ServerApp.cs
@@ -1366,7 +1366,7 @@ namespace ARK_Server_Manager.Lib
                 gotNewVersion = false;
 
                 // update the server cache
-                var steamCmdArgs = String.Format(Config.Default.SteamCmdInstallServerArgsFormat, Config.Default.AutoUpdate_CacheDir, "validate");
+                var steamCmdArgs = String.Format(Config.Default.SteamCmdInstallServerArgsFormat, Config.Default.AutoUpdate_CacheDir, string.Empty);
                 var success = ServerUpdater.UpgradeServerAsync(steamCmdFile, steamCmdArgs, Config.Default.AutoUpdate_CacheDir, Config.Default.SteamCmdRedirectOutput ? serverOutputHandler : null, CancellationToken.None, ProcessWindowStyle.Hidden).Result;
                 if (success && downloadSuccessful)
                     // download was successful, exit loop and continue.


### PR DESCRIPTION
Doing a full validate on our automatic update check is rough on the disk, so don't run validate here. I left validate enabled on other checks though.

I'm currently running this, feel free to keep the PR open and let me be the guinea pig for additional changes or whatnot.

Discussion here: http://arkservermanager.freeforums.net/thread/3450/frequent-patch-checking-performance-issues?page=1&scrollTo=22247